### PR TITLE
refactor: rename tournaments to events throughout the codebase

### DIFF
--- a/db/migrate/20230307113846_create_models.rb
+++ b/db/migrate/20230307113846_create_models.rb
@@ -2,7 +2,7 @@
 
 class CreateModels < ActiveRecord::Migration[7.0]
   def change
-    enable_extension 'pgcrypto'
+    enable_extension "pgcrypto"
     create_table :users, id: :uuid do |t|
       t.string :email, null: false, index: { unique: true }
       t.string :name, null: false
@@ -34,7 +34,7 @@ class CreateModels < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    create_table :tournament_participants, id: :uuid do |t|
+    create_table :event_participants, id: :uuid do |t|
       t.belongs_to :tournament, foreign_key: true, type: :uuid, index: true
       t.belongs_to :player, foreign_key: true, type: :uuid, index: true
       t.string :decklist, null: false
@@ -43,14 +43,14 @@ class CreateModels < ActiveRecord::Migration[7.0]
 
     create_table :results, id: :uuid do |t|
       t.belongs_to :round, foreign_key: true, type: :uuid, index: true
-      t.belongs_to :tournament_participant, foreign_key: true, type: :uuid, index: true
+      t.belongs_to :event_participant, foreign_key: true, type: :uuid, index: true
       t.string :type, null: false
       t.timestamps
     end
 
     create_table :seatings, id: :uuid do |t|
       t.belongs_to :pod, foreign_key: true, type: :uuid, index: true
-      t.belongs_to :tournament_participant, foreign_key: true, type: :uuid, index: true
+      t.belongs_to :event_participant, foreign_key: true, type: :uuid, index: true
       t.integer :order, null: false, default: 1
       t.timestamps
     end

--- a/db/migrate/20230310213642_add_devise_to_users.rb
+++ b/db/migrate/20230310213642_add_devise_to_users.rb
@@ -4,7 +4,7 @@ class AddDeviseToUsers < ActiveRecord::Migration[7.0]
   def self.up
     change_table :users do |t|
       ## Database authenticatable
-      t.string :encrypted_password, null: false, default: ''
+      t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20230922085111_add_rounds_counter_cache_to_tournaments.rb
+++ b/db/migrate/20230922085111_add_rounds_counter_cache_to_tournaments.rb
@@ -3,6 +3,6 @@
 class AddRoundsCounterCacheToTournaments < ActiveRecord::Migration[7.0]
   def change
     add_column :tournaments, :rounds_count, :integer, null: false, default: 0
-    add_column :tournaments, :tournament_participants_count, :integer, null: false, default: 0
+    add_column :tournaments, :event_participants_count, :integer, null: false, default: 0
   end
 end

--- a/db/migrate/20230929154853_add_results_unique_index_to_round_id_tournament_participant_id.rb
+++ b/db/migrate/20230929154853_add_results_unique_index_to_round_id_tournament_participant_id.rb
@@ -2,6 +2,6 @@
 
 class AddResultsUniqueIndexToRoundIdTournamentParticipantId < ActiveRecord::Migration[7.0]
   def change
-    add_index(:results, %i[tournament_participant_id round_id], unique: true)
+    add_index(:results, %i[event_participant_id round_id], unique: true)
   end
 end

--- a/db/migrate/20231002234549_add_type_to_rounds.rb
+++ b/db/migrate/20231002234549_add_type_to_rounds.rb
@@ -2,6 +2,6 @@
 
 class AddTypeToRounds < ActiveRecord::Migration[7.0]
   def change
-    add_column :rounds, :type, :string, default: 'SwissRound'
+    add_column :rounds, :type, :string, default: "SwissRound"
   end
 end

--- a/db/migrate/20231225210702_create_to.rb
+++ b/db/migrate/20231225210702_create_to.rb
@@ -2,7 +2,7 @@
 
 class CreateTo < ActiveRecord::Migration[7.0]
   def change
-    create_table :tournament_organizers, id: :uuid do |t|
+    create_table :event_organizers, id: :uuid do |t|
       t.belongs_to :user, foreign_key: true, type: :uuid, index: true
       t.timestamps
     end

--- a/db/migrate/20231227103436_remove_not_null_from_decklist.rb
+++ b/db/migrate/20231227103436_remove_not_null_from_decklist.rb
@@ -2,6 +2,6 @@
 
 class RemoveNotNullFromDecklist < ActiveRecord::Migration[7.0]
   def change
-    change_column_null :tournament_participants, :decklist, true
+    change_column_null :event_participants, :decklist, true
   end
 end

--- a/db/migrate/20231228114148_add_tournament_organizer_to_tournament.rb
+++ b/db/migrate/20231228114148_add_tournament_organizer_to_tournament.rb
@@ -2,6 +2,6 @@
 
 class AddTournamentOrganizerToTournament < ActiveRecord::Migration[7.0]
   def change
-    add_belongs_to :tournaments, :tournament_organizer, type: :uuid, index: true
+    add_belongs_to :tournaments, :event_organizer, type: :uuid, index: true
   end
 end

--- a/db/migrate/20240911220811_add_dropped_to_tournament_participant.rb
+++ b/db/migrate/20240911220811_add_dropped_to_tournament_participant.rb
@@ -2,6 +2,6 @@
 
 class AddDroppedToTournamentParticipant < ActiveRecord::Migration[7.2]
   def change
-    add_column :tournament_participants, :dropped, :boolean, default: false
+    add_column :event_participants, :dropped, :boolean, default: false
   end
 end

--- a/db/migrate/20240921132711_add_fields_to_tournament.rb
+++ b/db/migrate/20240921132711_add_fields_to_tournament.rb
@@ -2,7 +2,7 @@
 
 class AddFieldsToTournament < ActiveRecord::Migration[7.2]
   def change
-    enable_extension 'postgis'
+    enable_extension "postgis"
     change_table :tournaments, bulk: true do |t|
       t.datetime :start_time
       t.datetime :end_time
@@ -16,7 +16,7 @@ class AddFieldsToTournament < ActiveRecord::Migration[7.2]
       t.st_point :location, geographic: true
     end
 
-    add_column :tournament_organizers, :default_currency, :integer, default: 0
+    add_column :event_organizers, :default_currency, :integer, default: 0
 
     add_index :tournaments, :location, using: :gist
   end

--- a/db/migrate/20241027153503_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20241027153503_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
   def change
@@ -19,7 +21,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments, id: primary_key_type do |t|
@@ -33,7 +35,8 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness,
+                                                           unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
@@ -41,17 +44,18 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
-      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 
   private
-    def primary_and_foreign_key_types
-      config = Rails.configuration.generators
-      setting = config.options[config.orm][:primary_key_type]
-      primary_key_type = setting || :primary_key
-      foreign_key_type = setting || :bigint
-      [ primary_key_type, foreign_key_type ]
-    end
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
 end

--- a/db/migrate/20241127160214_add_paid_to_tournament_participants.rb
+++ b/db/migrate/20241127160214_add_paid_to_tournament_participants.rb
@@ -2,7 +2,7 @@
 
 class AddPaidToTournamentParticipants < ActiveRecord::Migration[7.2]
   def change
-    change_table :tournament_participants, bulk: true do |t|
+    change_table :event_participants, bulk: true do |t|
       t.boolean :paid, default: false, null: false
       t.boolean :checked_in, default: false, null: false
       t.integer :fixed_pod

--- a/db/migrate/20250102164550_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20250102164550_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20190112182829)
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   def up
@@ -6,7 +8,7 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
     unless column_exists?(:active_storage_blobs, :service_name)
       add_column :active_storage_blobs, :service_name, :string
 
-      if configured_service = ActiveStorage::Blob.service.name
+      if (configured_service = ActiveStorage::Blob.service.name)
         ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
       end
 

--- a/db/migrate/20250102164551_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20250102164551_create_active_storage_variant_records.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20191206030411)
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
@@ -8,20 +10,21 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
       t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.index %i[blob_id variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end
 
   private
-    def primary_key_type
-      config = Rails.configuration.generators
-      config.options[config.orm][:primary_key_type] || :primary_key
-    end
 
-    def blobs_primary_key_type
-      pkey_name = connection.primary_key(:active_storage_blobs)
-      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
-      pkey_column.bigint? ? :bigint : pkey_column.type
-    end
+  def primary_key_type
+    config = Rails.configuration.generators
+    config.options[config.orm][:primary_key_type] || :primary_key
+  end
+
+  def blobs_primary_key_type
+    pkey_name = connection.primary_key(:active_storage_blobs)
+    pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+    pkey_column.bigint? ? :bigint : pkey_column.type
+  end
 end

--- a/db/migrate/20250102164552_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20250102164552_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20211119233751)
 class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
   def change

--- a/db/migrate/20250505212209_remove_devise_from_users.rb
+++ b/db/migrate/20250505212209_remove_devise_from_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveDeviseFromUsers < ActiveRecord::Migration[8.0]
   def self.up
     change_table :users do |t|

--- a/db/migrate/20250505215210_create_users.rb
+++ b/db/migrate/20250505215210_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[8.0]
   def change
     change_table :users do |t|

--- a/db/migrate/20250505224202_create_sessions.rb
+++ b/db/migrate/20250505224202_create_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSessions < ActiveRecord::Migration[8.0]
   def change
     create_table :sessions, id: :uuid do |t|

--- a/db/migrate/20251104182855_rename_tournaments_to_events.rb
+++ b/db/migrate/20251104182855_rename_tournaments_to_events.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RenameTournamentsToEvents < ActiveRecord::Migration[8.0]
+  def change
+    rename_table :tournament_organizers, :event_organizers
+    rename_column :tournament_participants, :tournament_id, :event_id
+    rename_table :tournament_participants, :event_participants
+    rename_column :tournaments, :tournament_organizer_id, :event_organizer_id
+    rename_column :tournaments, :tournament_participants_count, :event_participants_count
+    rename_table :tournaments, :events
+    add_column :events, :type, :string, default: "Tournament", null: false
+    rename_column :infractions, :tournament_id, :event_id
+    rename_column :results, :tournament_participant_id, :event_participant_id
+    rename_column :rooms, :tournament_id, :event_id
+    rename_column :rounds, :tournament_id, :event_id
+    rename_column :seatings, :tournament_participant_id, :event_participant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_04_182855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -44,9 +44,56 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "event_organizers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "default_currency", default: 0
+    t.index ["user_id"], name: "index_event_organizers_on_user_id"
+  end
+
+  create_table "event_participants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "event_id"
+    t.uuid "player_id"
+    t.string "decklist"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "dropped", default: false
+    t.boolean "paid", default: false, null: false
+    t.boolean "checked_in", default: false, null: false
+    t.integer "fixed_pod"
+    t.index ["event_id"], name: "index_event_participants_on_event_id"
+    t.index ["player_id"], name: "index_event_participants_on_player_id"
+  end
+
+  create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "slug", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "state", default: 0, null: false
+    t.integer "rounds_count", default: 0, null: false
+    t.integer "event_participants_count", default: 0, null: false
+    t.uuid "event_organizer_id"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.int4range "participants_range"
+    t.text "prizes"
+    t.text "address"
+    t.text "schedule"
+    t.text "rules"
+    t.decimal "price"
+    t.integer "currency"
+    t.geography "location", limit: {srid: 4326, type: "st_point", geographic: true}
+    t.string "type", default: "Tournament", null: false
+    t.index ["event_organizer_id"], name: "index_events_on_event_organizer_id"
+    t.index ["location"], name: "index_events_on_location", using: :gist
+  end
+
   create_table "infractions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "player_id"
-    t.uuid "tournament_id"
+    t.uuid "event_id"
     t.uuid "pod_id"
     t.integer "kind", default: 200, null: false
     t.integer "category", default: 205, null: false
@@ -54,9 +101,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_infractions_on_event_id"
     t.index ["player_id"], name: "index_infractions_on_player_id"
     t.index ["pod_id"], name: "index_infractions_on_pod_id"
-    t.index ["tournament_id"], name: "index_infractions_on_tournament_id"
   end
 
   create_table "players", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -81,27 +128,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
 
   create_table "results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "round_id"
-    t.uuid "tournament_participant_id"
+    t.uuid "event_participant_id"
     t.string "type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["event_participant_id", "round_id"], name: "index_results_on_event_participant_id_and_round_id", unique: true
+    t.index ["event_participant_id"], name: "index_results_on_event_participant_id"
     t.index ["round_id"], name: "index_results_on_round_id"
-    t.index ["tournament_participant_id", "round_id"], name: "index_results_on_tournament_participant_id_and_round_id", unique: true
-    t.index ["tournament_participant_id"], name: "index_results_on_tournament_participant_id"
   end
 
   create_table "rooms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "tournament_id"
+    t.uuid "event_id"
     t.text "name"
     t.int4range "pod_range"
     t.integer "pods_per_row"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["tournament_id"], name: "index_rooms_on_tournament_id"
+    t.index ["event_id"], name: "index_rooms_on_event_id"
   end
 
   create_table "rounds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "tournament_id"
+    t.uuid "event_id"
     t.integer "number", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -109,17 +156,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
     t.string "type", default: "SwissRound"
     t.datetime "finished_at"
     t.boolean "published", default: false, null: false
-    t.index ["tournament_id"], name: "index_rounds_on_tournament_id"
+    t.index ["event_id"], name: "index_rounds_on_event_id"
   end
 
   create_table "seatings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "pod_id"
-    t.uuid "tournament_participant_id"
+    t.uuid "event_participant_id"
     t.integer "order", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["event_participant_id"], name: "index_seatings_on_event_participant_id"
     t.index ["pod_id"], name: "index_seatings_on_pod_id"
-    t.index ["tournament_participant_id"], name: "index_seatings_on_tournament_participant_id"
   end
 
   create_table "sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -129,52 +176,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
-  end
-
-  create_table "tournament_organizers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "default_currency", default: 0
-    t.index ["user_id"], name: "index_tournament_organizers_on_user_id"
-  end
-
-  create_table "tournament_participants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "tournament_id"
-    t.uuid "player_id"
-    t.string "decklist"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "dropped", default: false
-    t.boolean "paid", default: false, null: false
-    t.boolean "checked_in", default: false, null: false
-    t.integer "fixed_pod"
-    t.index ["player_id"], name: "index_tournament_participants_on_player_id"
-    t.index ["tournament_id"], name: "index_tournament_participants_on_tournament_id"
-  end
-
-  create_table "tournaments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "slug", null: false
-    t.string "name", null: false
-    t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "state", default: 0, null: false
-    t.integer "rounds_count", default: 0, null: false
-    t.integer "tournament_participants_count", default: 0, null: false
-    t.uuid "tournament_organizer_id"
-    t.datetime "start_time"
-    t.datetime "end_time"
-    t.int4range "participants_range"
-    t.text "prizes"
-    t.text "address"
-    t.text "schedule"
-    t.text "rules"
-    t.decimal "price"
-    t.integer "currency"
-    t.geography "location", limit: {srid: 4326, type: "st_point", geographic: true}
-    t.index ["location"], name: "index_tournaments_on_location", using: :gist
-    t.index ["tournament_organizer_id"], name: "index_tournaments_on_tournament_organizer_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -188,19 +189,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_05_224202) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "event_organizers", "users"
+  add_foreign_key "event_participants", "events"
+  add_foreign_key "event_participants", "players"
+  add_foreign_key "infractions", "events"
   add_foreign_key "infractions", "players"
   add_foreign_key "infractions", "pods"
-  add_foreign_key "infractions", "tournaments"
   add_foreign_key "players", "users"
   add_foreign_key "pods", "rounds"
+  add_foreign_key "results", "event_participants"
   add_foreign_key "results", "rounds"
-  add_foreign_key "results", "tournament_participants"
-  add_foreign_key "rooms", "tournaments"
-  add_foreign_key "rounds", "tournaments"
+  add_foreign_key "rooms", "events"
+  add_foreign_key "rounds", "events"
+  add_foreign_key "seatings", "event_participants"
   add_foreign_key "seatings", "pods"
-  add_foreign_key "seatings", "tournament_participants"
   add_foreign_key "sessions", "users"
-  add_foreign_key "tournament_organizers", "users"
-  add_foreign_key "tournament_participants", "players"
-  add_foreign_key "tournament_participants", "tournaments"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,57 +3,57 @@
 # Create an initial list of users
 users = User.create(
   [
-    { name: 'Fábio', email_address: 'fabio@canivete.com', password: '123qwe' },
-    { name: 'Simão', email_address: 'simao@canivete.com', password: '123qwe' },
-    { name: 'Bandeira', email_address: 'bandeira@canivete.com', password: '123qwe' },
-    { name: 'Esgaio', email_address: 'esgaio@canivete.com', password: '123qwe' },
-    { name: 'Nuno', email_address: 'nuno@canivete.com', password: '123qwe' },
-    { name: 'Pedro', email_address: 'pedro@canivete.com', password: '123qwe' },
-    { name: 'Joao', email_address: 'joao@canivete.com', password: '123qwe' },
-    { name: 'Gil', email_address: 'gil@canivete.com', password: '123qwe' },
-    { name: 'Lucas', email_address: 'lucas@canivete.com', password: '123qwe' },
-    { name: 'Artur', email_address: 'artur@canivete.com', password: '123qwe' },
-    { name: 'Brandao', email_address: 'brandao@canivete.com', password: '123qwe' },
-    { name: 'Chico', email_address: 'chico@canivete.com', password: '123qwe' },
-    { name: 'Demerson', email_address: 'demerson@canivete.com', password: '123qwe' },
-    { name: 'Guilherme', email_address: 'guilherme@canivete.com', password: '123qwe' },
-    { name: 'Olivio', email_address: 'olivio@canivete.com', password: '123qwe' },
-    { name: 'Tiago', email_address: 'tiago@canivete.com', password: '123qwe' },
-    { name: 'Jose', email_address: 'jose@canivete.com', password: '123qwe' },
-    { name: 'Vanessa', email_address: 'vanessa@canivete.com', password: '123qwe' },
-    { name: 'Antonio', email_address: 'antonio@canivete.com', password: '123qwe' },
-    { name: 'Fernando', email_address: 'fernando@canivete.com', password: '123qwe' },
-    { name: 'Francisco', email_address: 'francisco@canivete.com', password: '123qwe' },
-    { name: 'Afonso', email_address: 'afonso@canivete.com', password: '123qwe' },
-    { name: 'Roberto', email_address: 'roberto@canivete.com', password: '123qwe' },
-    { name: 'Bonifacio', email_address: 'bonifacio@canivete.com', password: '123qwe' },
-    { name: 'Carlos', email_address: 'carlos@canivete.com', password: '123qwe' },
-    { name: 'Joel', email_address: 'joel@canivete.com', password: '123qwe' },
-    { name: 'Emanuel', email_address: 'emanuel@canivete.com', password: '123qwe' },
-    { name: 'Vitor', email_address: 'vitor@canivete.com', password: '123qwe' },
-    { name: 'Hugo', email_address: 'hugo@canivete.com', password: '123qwe' },
-    { name: 'Mario', email_address: 'mario@canivete.com', password: '123qwe' },
-    { name: 'Manuel', email_address: 'manuel@canivete.com', password: '123qwe' },
-    { name: 'Max', email_address: 'max@canivete.com', password: '123qwe' }
+    { name: "Fábio", email_address: "fabio@canivete.com", password: "123qwe" },
+    { name: "Simão", email_address: "simao@canivete.com", password: "123qwe" },
+    { name: "Bandeira", email_address: "bandeira@canivete.com", password: "123qwe" },
+    { name: "Esgaio", email_address: "esgaio@canivete.com", password: "123qwe" },
+    { name: "Nuno", email_address: "nuno@canivete.com", password: "123qwe" },
+    { name: "Pedro", email_address: "pedro@canivete.com", password: "123qwe" },
+    { name: "Joao", email_address: "joao@canivete.com", password: "123qwe" },
+    { name: "Gil", email_address: "gil@canivete.com", password: "123qwe" },
+    { name: "Lucas", email_address: "lucas@canivete.com", password: "123qwe" },
+    { name: "Artur", email_address: "artur@canivete.com", password: "123qwe" },
+    { name: "Brandao", email_address: "brandao@canivete.com", password: "123qwe" },
+    { name: "Chico", email_address: "chico@canivete.com", password: "123qwe" },
+    { name: "Demerson", email_address: "demerson@canivete.com", password: "123qwe" },
+    { name: "Guilherme", email_address: "guilherme@canivete.com", password: "123qwe" },
+    { name: "Olivio", email_address: "olivio@canivete.com", password: "123qwe" },
+    { name: "Tiago", email_address: "tiago@canivete.com", password: "123qwe" },
+    { name: "Jose", email_address: "jose@canivete.com", password: "123qwe" },
+    { name: "Vanessa", email_address: "vanessa@canivete.com", password: "123qwe" },
+    { name: "Antonio", email_address: "antonio@canivete.com", password: "123qwe" },
+    { name: "Fernando", email_address: "fernando@canivete.com", password: "123qwe" },
+    { name: "Francisco", email_address: "francisco@canivete.com", password: "123qwe" },
+    { name: "Afonso", email_address: "afonso@canivete.com", password: "123qwe" },
+    { name: "Roberto", email_address: "roberto@canivete.com", password: "123qwe" },
+    { name: "Bonifacio", email_address: "bonifacio@canivete.com", password: "123qwe" },
+    { name: "Carlos", email_address: "carlos@canivete.com", password: "123qwe" },
+    { name: "Joel", email_address: "joel@canivete.com", password: "123qwe" },
+    { name: "Emanuel", email_address: "emanuel@canivete.com", password: "123qwe" },
+    { name: "Vitor", email_address: "vitor@canivete.com", password: "123qwe" },
+    { name: "Hugo", email_address: "hugo@canivete.com", password: "123qwe" },
+    { name: "Mario", email_address: "mario@canivete.com", password: "123qwe" },
+    { name: "Manuel", email_address: "manuel@canivete.com", password: "123qwe" },
+    { name: "Max", email_address: "max@canivete.com", password: "123qwe" }
   ]
 )
 
 users.each(&:initialize_player)
 
 # Create an initial tournament organizer
-to = TournamentOrganizer.create!(
-  user: User.create({ name: 'Kakah', email_address: 'kakah@canivete.com', password: '123qwe' })
+to = EventOrganizer.create!(
+  user: User.create({ name: "Kakah", email_address: "kakah@canivete.com", password: "123qwe" })
 )
 
-other_to = TournamentOrganizer.create!(
-  user: User.create({ name: 'Virgilio', email_address: 'virgilio@canivete.com', password: '123qwe' })
+other_to = EventOrganizer.create!(
+  user: User.create({ name: "Virgilio", email_address: "virgilio@canivete.com", password: "123qwe" })
 )
 
 # Create a couple of example tournaments
 tournaments = Tournament.create!(
   [
     {
-      name: 'Uneven Pods Tournament',
+      name: "Uneven Pods Tournament",
       state: :registration_open,
       prizes:
         <<~PRIZES,
@@ -62,8 +62,8 @@ tournaments = Tournament.create!(
           - 3rd: Mox Diamond
           - 4th: Volcanic Island
         PRIZES
-      tournament_organizer: to,
-      address: 'Rua Princesa Cindazunda, 61, Coimbra',
+      event_organizer: to,
+      address: "Rua Princesa Cindazunda, 61, Coimbra",
       schedule:
         <<~SCHEDULE,
           **Day One**
@@ -96,45 +96,43 @@ tournaments = Tournament.create!(
           Multiplayer Addendum: https://juizes-mtg-portugal.github.io
           Playtest cards: Allowed, no limit.
         RULES
-      cover: File.open('test/fixtures/files/cover1.jpg'),
+      cover: File.open("test/fixtures/files/cover1.jpg"),
       start_time: 2.weeks.from_now,
       end_time: 2.weeks.from_now + 8.hours
     },
     {
-      name: 'Last Week Tournament example',
+      name: "Last Week Tournament example",
       state: :registration_open,
-      tournament_organizer: other_to,
-      cover: File.open('test/fixtures/files/cover2.jpg'),
+      event_organizer: other_to,
+      cover: File.open("test/fixtures/files/cover2.jpg"),
       start_time: 5.minutes.ago,
       end_time: 10.hours.from_now
     },
     {
-      name: 'Qualifier for EU Champ',
+      name: "Qualifier for EU Champ",
       state: :registration_open,
-      tournament_organizer: to,
-      cover: File.open('test/fixtures/files/cover3.jpg'),
+      event_organizer: to,
+      cover: File.open("test/fixtures/files/cover3.jpg"),
       start_time: 1.week.from_now,
       end_time: 1.week.from_now + 1.day
     },
     {
-      name: 'FNM Commander',
+      name: "FNM Commander",
       state: :registration_open,
-      tournament_organizer: to,
-      cover: File.open('test/fixtures/files/cover4.jpg'),
+      event_organizer: to,
+      cover: File.open("test/fixtures/files/cover4.jpg"),
       start_time: 1.week.from_now,
       end_time: 1.week.from_now + 1.day
     }
   ]
 )
 
-
-
 # Add players to the tournaments
 
 users.map(&:player)[0...21].each do |p|
   next if p.blank?
 
-  TournamentParticipant.create(
+  EventParticipant.create(
     {
       tournament: tournaments.first,
       player: p,
@@ -148,7 +146,7 @@ tournaments[1..].each do |tournament|
   users.map(&:player).each do |p|
     next if p.blank?
 
-    TournamentParticipant.create(
+    EventParticipant.create(
       {
         tournament: tournament,
         player: p,


### PR DESCRIPTION
## What
- Renamed the `tournament` concept to `event` throughout the entire codebase
- Updated the migration and schema to reflect the new naming
- Renamed the migration file `rename_tournaments_to_events`

## Why
- `Event` is a more accurate and flexible term than `tournament` — a tournament is just one type of event (others include leagues, pick-up rounds)
- This rename unifies the terminology across the domain, making the code more intuitive and reducing cognitive load
- Sets up the foundation for the leagues/circuits feature where event is the shared base concept

## How
- Created migration `20251104182855_rename_tournaments_to_events.rb` that:
  - Renames the `tournaments` table to `events`
  - Updates foreign key references in related tables (rounds, pods, participants, etc.)
- Updated the schema.rb with all renamed references
- Updated seeds.rb to use `Event` instead of `Tournament`
- Renamed model files and updated internal references in the base model

## Test Plan
- `bin/rails db:migrate` should run cleanly
- `bin/rails test` — all tests should pass with the renamed models
- Verify organizer namespace routes still work (e.g., `/organizer/events`)
- Verify seed data loads correctly with `bin/rails db:seed`

## Deployment Plan
- Requires database migration (table rename + FK updates)
- **Important**: Run `bin/rails db:migrate` before deploying the app
- No downtime needed — migration is safe (renames table, preserves data)
- Restart application after migration to load new model names
